### PR TITLE
Require OUnit 2.2.2 or later

### DIFF
--- a/lambda-dti.opam
+++ b/lambda-dti.opam
@@ -15,6 +15,7 @@ build-test: [
 depends: [
   "dune" {build & >="1.2.0" & < "2"}
   "menhir"
-  "ounit" {test & >="2.0.0" & < "3"}
+  # 2.2.2 is the final version to support OCaml 4.03
+  "ounit" {test & >="2.2.2" & < "3"}
 ]
 available: [ocaml-version >= "4.03.0"]


### PR DESCRIPTION
To resolve build errors on CI:
```
[ERROR] The installation of ounit failed at "make install-ounit version=2.1.2".
- ocamlfind install oUnit src/lib/oUnit/META -patch-version 2.1.2
- Installed /Users/runner/work/lambda-dti/lambda-dti/_opam/lib/oUnit/META
- dune install ounit
- Error: mkdir: _build: Operation not permitted
- make: *** [install-ounit] Error 1
- ocamlfind install oUnit src/lib/oUnit/META -patch-version 2.1.2
- Installed /Users/runner/work/lambda-dti/lambda-dti/_opam/lib/oUnit/META
- dune install ounit
- Error: mkdir: _build: Operation not permitted
- make: *** [install-ounit] Error 1
```