### PR TITLE
Upgrade dune to 2.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
           - 4.09.x
           - 4.10.x
           - 4.11.x
+          - 4.12.x
+          - 4.13.x
+          - 4.14.x
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocaml/opam:alpine-3.15-ocaml-4.07
+FROM ocaml/opam:alpine-3.15-ocaml-4.14
 
 USER root
 RUN apk --update add m4
@@ -12,7 +12,7 @@ FROM alpine:3.15
 RUN echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
 RUN apk --update add rlwrap@testing
 
-COPY --from=0 /home/opam/.opam/4.07/bin/ldti /usr/bin/
+COPY --from=0 /home/opam/.opam/4.14/bin/ldti /usr/bin/
 
 # Workaround: sleep for 1 second to avoid the following error:
 # rlwrap: error: My terminal reports width=0

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is the artifact of the following paper in POPL 2019.
 ## Requirements
 - opam 2.0.0+
 - OCaml 4.03.0+
-- Dune 1.2.0+ (formerly known as Jbuilder)
+- Dune 2.0.0+ (formerly known as Jbuilder)
 - Menhir
 - OUnit 2 (optional for running unit tests)
 - [rlwrap](https://github.com/hanslub42/rlwrap) (optional for line editing and input history)

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 1.2)
-(using menhir 1.0)
+(lang dune 2.0)
+(using menhir 2.0)

--- a/lambda-dti.opam
+++ b/lambda-dti.opam
@@ -13,7 +13,7 @@ build-test: [
   ["dune" "runtest" "-p" name "-j" jobs]
 ]
 depends: [
-  "dune" {build & >="1.2.0" & < "2"}
+  "dune" {build & >="2.0" & < "3"}
   "menhir"
   # 2.2.2 is the final version to support OCaml 4.03
   "ounit" {test & >="2.2.2" & < "3"}

--- a/test/dune
+++ b/test/dune
@@ -2,7 +2,6 @@
   (name runtests)
   (libraries oUnit lambda_dti))
 
-(alias
-  (name    runtest)
-  (deps    runtests.exe)
-  (action  (run %{deps})))
+(rule
+   (alias runtest)
+   (action (run ./runtests.exe)))


### PR DESCRIPTION
- Support OCaml 4.12 and later. Error message when building lambda-dti on OCaml 4.12
  ```
  > [stage-0 4/4] RUN opam pin add lambda-dti ./app:                                                                                              
  #12 0.804 Package lambda-dti does not exist, create as a NEW package? [Y/n] y                                                                    
  #12 0.805 [lambda-dti.~dev: rsync]                                                                                                               
  #12 0.850 [lambda-dti.~dev] synchronised from file:///home/opam/app                                                                              
  #12 0.851 [WARNING] Failed checks on lambda-dti package definition from source at file:///home/opam/app:                                         
  #12 0.851              error 57: Synopsis and description must not be both empty
  #12 0.852 lambda-dti is now pinned to file:///home/opam/app (version 2.1)
  #12 0.852 
  #12 4.136 The following dependencies couldn't be met:
  #12 4.136   - lambda-dti -> dune < 2 -> ocaml < 4.12
  #12 4.136       base of this switch (use `--unlock-base' to force)
  #12 4.136 
  #12 4.136 [NOTE] Pinning command successful, but your installed packages may be out of sync.
  ------
  executor failed running [/bin/sh -c opam pin add lambda-dti ./app]: exit code: 20
  ```
- Closes #7 as `menhir --infer` is enabled by default with dune 2.x.