### PR TITLE
Use macOS on Intel instead of ARM for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
+          - macos-13
           - ubuntu-latest
           - windows-latest
         ocaml-compiler:


### PR DESCRIPTION
The macos-latest runner now uses ARM-based macOS (M1) by default. As installing older versions of OCaml on M1 is failing on CI, I'm downgrading the macOS version to use for now.