### PR TITLE
Simplify installation of rlwrap on Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ RUN opam pin add lambda-dti ./app
 
 FROM alpine:3.20
 
-RUN echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
-RUN apk --update add rlwrap@testing
+RUN apk --update add rlwrap
 
 COPY --from=0 /home/opam/.opam/5.1/bin/ldti /usr/bin/
 


### PR DESCRIPTION
Alpine Linux provides rlwrap in the community repository now. https://pkgs.alpinelinux.org/packages?name=alpine&branch=v3.20