### PR TITLE
tyenv_bug

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -19,7 +19,7 @@ let rec read_eval_print lexbuf env tyenv =
 
       (* Type inference *)
       print_debug "***** Typing *****\n";
-      let tyenv, e, u = Typing.ITGL.type_of_program tyenv e in
+      let e, u = Typing.ITGL.type_of_program tyenv e in
       print_debug "e: %a\n" Pp.ITGL.pp_program e;
       print_debug "U: %a\n" Pp.pp_ty u;
 
@@ -29,7 +29,7 @@ let rec read_eval_print lexbuf env tyenv =
 
       (* Translation *)
       print_debug "***** Cast-insertion *****\n";
-      let tyenv, f, u' = Typing.ITGL.translate tyenv e in
+      let new_tyenv, f, u' = Typing.ITGL.translate tyenv e in
       print_debug "f: %a\n" Pp.CC.pp_program f;
       print_debug "U: %a\n" Pp.pp_ty u';
       assert (Typing.is_equal u u');
@@ -43,7 +43,7 @@ let rec read_eval_print lexbuf env tyenv =
         pp_print_string x
         Pp.pp_ty2 u
         Pp.CC.pp_value v;
-      read_eval_print lexbuf env tyenv
+      read_eval_print lexbuf env new_tyenv
     with
     | Failure message ->
       print "Failure: %s\n" message;

--- a/lib/stdlib.ml
+++ b/lib/stdlib.ml
@@ -67,12 +67,12 @@ let env, tyenv =
  List.fold_left
     (fun (env, tyenv) str ->
       let e = Parser.toplevel Lexer.main @@ Lexing.from_string str in
-      let tyenv, e, u = Typing.ITGL.type_of_program tyenv e in
+      let e, u = Typing.ITGL.type_of_program tyenv e in
       let tyenv, e, _ = Typing.ITGL.normalize tyenv e u in
-      let tyenv, f, _ = Typing.ITGL.translate tyenv e in
+      let new_tyenv, f, _ = Typing.ITGL.translate tyenv e in
       let _ = Typing.CC.type_of_program tyenv f in
       let env, _, _ = Eval.eval_program env f in
-      env, tyenv)
+      env, new_tyenv)
     (env, tyenv)
     implementations
 

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -169,6 +169,7 @@ module CC = struct
     | LetExp (r, _, _, _, _) -> r
 
   let rec is_value = function
+    | Var _
     | IConst _
     | BConst _
     | UConst _

--- a/lib/typing.ml
+++ b/lib/typing.ml
@@ -387,12 +387,10 @@ module ITGL = struct
 
   let type_of_program env = function
     | Exp e ->
-      env, Exp e, type_of_exp env e
+      Exp e, type_of_exp env e
     | LetDecl (x, e) ->
       let u = type_of_exp env e in
-      let xs = if is_value env e then closure_tyvars_let_decl e u env else [] in
-      let env = Environment.add x (TyScheme (xs, u)) env in
-      env, LetDecl (x, e), u
+      LetDecl (x, e), u
 
   (* Normalize type variables *)
 
@@ -517,6 +515,7 @@ module ITGL = struct
       env, CC.LetDecl (x, xs @ ys, f), u
     | LetDecl (x, e) ->
       let f, u = translate_exp env e in
+      let env = Environment.add x (tysc_of_ty u) env in
       env, CC.LetDecl (x, [], f), u
 end
 

--- a/lib/typing.mli
+++ b/lib/typing.mli
@@ -19,7 +19,7 @@ val tyarg_to_ty : Syntax.CC.tyarg -> ty
 module ITGL : sig
   open Syntax.ITGL
 
-  val type_of_program : tysc Environment.t -> program -> (tysc Environment.t * program * ty)
+  val type_of_program : tysc Environment.t -> program -> (program * ty)
 
   val normalize : tysc Environment.t -> program -> ty -> (tysc Environment.t * program * ty)
   val normalize_type : ty -> ty

--- a/test/test_typing.ml
+++ b/test/test_typing.ml
@@ -19,7 +19,7 @@ module ITGL = struct
     let test (program, expected) =
       program >:: fun ctxt ->
         let e = parse @@ program ^ ";;" in
-        let _, _, u = Typing.ITGL.type_of_program tyenv e in
+        let _, u = Typing.ITGL.type_of_program tyenv e in
         let u = Typing.ITGL.normalize_type u in
         assert_equal ~ctxt:ctxt ~printer:id expected @@ asprintf "%a" Pp.pp_ty2 u
     in


### PR DESCRIPTION
If you run programs below,
```
let f = fun x -> x;;
let f = fun x -> x f;;
f (fun x -> x) 4;;
```
ldti raise an error
`Fatal error: exception Lambda_dti.Typing.Type_bug("failed to cast tyarg to ty")`

This arose in CC.type_of_exp because `fun x -> x f` type in the second line is concidered under an environment which contain type information of the second f, not first one.
To fix this problem, I added some changes.
- typing.ml, typing.mli
  - omit tyenv from return values of ITGL.type_of_program
  - add type information into tyenv correctly in translate
- main.ml, test_examples.ml, stdlib.ml
  - follow the change about return values of ITGL.type_of_program
  - normalize tyenv and pass it to translate, CC.type_of_program
  - update tyenv with new_tyenv from translate
- test_typing.ml
  - follow the change about return values of ITGL.type_of_program
